### PR TITLE
Add logback config file

### DIFF
--- a/scala/sbt/dse/src/test/resources/logback.xml
+++ b/scala/sbt/dse/src/test/resources/logback.xml
@@ -1,0 +1,20 @@
+<!--
+  ~ Copyright DataStax, Inc.
+  ~
+  ~ Please see the included license file for details.
+  -->
+
+<configuration>
+
+  <!-- Since EmbeddedCassandra uses log4j and DSE uses logback, for the time being we need both
+       configuration files. OS EmbeddedCassandra needs to be adjusted to DSE logging. -->
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="WARN">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>


### PR DESCRIPTION
So that debug messages are not printed out when executing tests.

Logback logging config file is "redundant" since we already have
log4j.properties. The former is used by test process and is preferred
since it log4j can not be found on DSE classpath. The latter is used by
obsolete EmbeddedCassandra and needs to be removed in the future.