### PR TITLE
Allow leveraging examples on Java 11

### DIFF
--- a/java/gradle/dse/build.gradle
+++ b/java/gradle/dse/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "java"
-    id "com.github.johnrengelman.shadow" version "1.2.3"
+    id "com.github.johnrengelman.shadow" version "5.2.0"
 }
 
 group 'com.datastax.spark.example'

--- a/java/gradle/dse/gradle/wrapper/gradle-wrapper.properties
+++ b/java/gradle/dse/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-bin.zip

--- a/java/gradle/oss/build.gradle
+++ b/java/gradle/oss/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "java"
-    id "com.github.johnrengelman.shadow" version "1.2.3"
+    id "com.github.johnrengelman.shadow" version "5.2.0"
 }
 
 group 'com.datastax.spark.example'

--- a/java/gradle/oss/gradle/wrapper/gradle-wrapper.properties
+++ b/java/gradle/oss/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-bin.zip

--- a/java/sbt/dse/build.sbt
+++ b/java/sbt/dse/build.sbt
@@ -5,7 +5,7 @@ crossPaths := false
 
 autoScalaLibrary := false
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.11.12"
 
 resolvers += Resolver.mavenLocal // for testing
 resolvers += "DataStax Repo" at "https://repo.datastax.com/public-repos/"

--- a/java/sbt/oss/build.sbt
+++ b/java/sbt/oss/build.sbt
@@ -5,7 +5,7 @@ crossPaths := false
 
 autoScalaLibrary := false
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.11.12"
 
 val sparkVersion = "2.2.2"
 val connectorVersion = "2.0.10"

--- a/scala/gradle/dse/build.gradle
+++ b/scala/gradle/dse/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "scala"
-    id "com.github.johnrengelman.shadow" version "1.2.3"
+    id "com.github.johnrengelman.shadow" version "5.2.0"
 }
 
 group 'com.datastax.spark.example'

--- a/scala/gradle/dse/gradle/wrapper/gradle-wrapper.properties
+++ b/scala/gradle/dse/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-bin.zip

--- a/scala/gradle/oss/build.gradle
+++ b/scala/gradle/oss/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "scala"
-    id "com.github.johnrengelman.shadow" version "1.2.3"
+    id "com.github.johnrengelman.shadow" version "5.2.0"
 }
 
 group 'com.datastax.spark.example'
@@ -30,6 +30,7 @@ configurations {
 // Please make sure that following dependencies have versions corresponding to the ones in your cluster.
 // Note that spark-cassandra-connector should be provided with '--packages' flag to spark-submit command.
 dependencies {
+    compile 'org.scala-lang:scala-library:2.11.12'
     provided "org.apache.spark:spark-core_$scalaVersion:$sparkVersion"
     provided "org.apache.spark:spark-sql_$scalaVersion:$sparkVersion"
     provided "org.apache.spark:spark-hive_$scalaVersion:$sparkVersion"

--- a/scala/gradle/oss/gradle/wrapper/gradle-wrapper.properties
+++ b/scala/gradle/oss/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-bin.zip

--- a/scala/maven/dse/pom.xml
+++ b/scala/maven/dse/pom.xml
@@ -10,7 +10,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <dse.version>6.8.35</dse.version>
-    <scala.version>2.11.8</scala.version>
+    <scala.version>2.11.12</scala.version>
     <scala.main.version>2.11</scala.main.version>
     <scalatest.version>3.0.0</scalatest.version>
     <connector.version>2.0.10</connector.version>
@@ -60,6 +60,9 @@
             </goals>
             <configuration>
               <mainSourceDir>${project.build.sourceDirectory}/../scala</mainSourceDir>
+              <args>
+                <arg>-nobootcp</arg>
+              </args>
             </configuration>
           </execution>
         </executions>

--- a/scala/maven/oss/pom.xml
+++ b/scala/maven/oss/pom.xml
@@ -9,7 +9,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <scala.version>2.11.8</scala.version>
+    <scala.version>2.11.12</scala.version>
     <scala.main.version>2.11</scala.main.version>
     <spark.version>2.2.2</spark.version>
     <connector.version>2.0.10</connector.version>
@@ -78,6 +78,9 @@
             </goals>
             <configuration>
               <mainSourceDir>${project.build.sourceDirectory}/../scala</mainSourceDir>
+              <args>
+                <arg>-nobootcp</arg>
+              </args>
             </configuration>
           </execution>
         </executions>

--- a/scala/sbt/dse/build.sbt
+++ b/scala/sbt/dse/build.sbt
@@ -1,7 +1,7 @@
 name := "writeRead"
 version := "0.1"
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.11.12"
 
 resolvers += Resolver.mavenLocal // for testing
 resolvers += "DataStax Repo" at "https://repo.datastax.com/public-repos/"

--- a/scala/sbt/oss/build.sbt
+++ b/scala/sbt/oss/build.sbt
@@ -1,7 +1,7 @@
 name := "writeRead"
 version := "0.1"
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.11.12"
 
 val sparkVersion = "2.2.2"
 val connectorVersion = "2.0.10"


### PR DESCRIPTION
- Upgrade Gradle wrapper from 4.9 to 5.0
- Upgrade Shadow plugin from 1.2.3 to 5.2.0
- Add Scala compiler flags (-nobootcp) for compatibility
- Change Scala to 2.11.12